### PR TITLE
Log structured flash storage.

### DIFF
--- a/kvs/include/storage.hpp
+++ b/kvs/include/storage.hpp
@@ -1,0 +1,51 @@
+#ifndef __STORAGE_H__
+#define __STORAGE_H__
+
+#include <string>
+
+void fail();
+
+class Storage {
+  public:
+    enum Status {
+        STORAGE_OK,
+        STORAGE_INVALID_ARG,
+        STORAGE_STORAGE_FAILURE,
+    };
+
+    virtual bool Init() = 0;
+    Status Put(const char* key, const char* value);
+    std::string Get(const char* key);
+    std::string List() const;
+
+    static const uint32_t kBlockSize = 4096;
+    static const char* kMagic;
+
+  protected:
+    virtual void Write(uint32_t pos, const char*buf, uint32_t length) = 0;
+    virtual void Read(uint32_t pos, char* buf, uint32_t length) = 0;
+    virtual void Erase(uint32_t pos, uint32_t size) = 0;
+
+    virtual void ReadNext(uint32_t* pos, char* buf, uint32_t length) {
+        Read(*pos, buf, length);
+        *pos += length;
+    }
+};
+
+class FlashStorage : public Storage {
+  public:
+    bool Init() override;
+
+  protected:
+    void Write(uint32_t pos, const char*buf, uint32_t length) override;
+    void Read(uint32_t pos, char *buf, uint32_t length) override;
+    void Erase(uint32_t pos, uint32_t size) override;
+
+  private:
+    void BoundsCheck(const char *op, uint32_t pos, uint32_t length);
+    // Data partition
+    uint32_t start_ = ~0;
+    uint32_t length_ = ~0;
+};
+
+#endif  // __STORAGE_H__

--- a/kvs/platformio.ini
+++ b/kvs/platformio.ini
@@ -8,9 +8,17 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
+[env]
+test_framework = googletest
+
 [env:esp32dev]
 platform = espressif32
 board = esp32dev
 framework = arduino
 monitor_speed = 115200
 board_build.partitions = noota_ffat.csv
+monitor_filters = esp32_exception_decoder
+test_framework = googletest
+;build_flags = -std=c++17
+;build_unflags = -std=gnu++11
+

--- a/kvs/src/main.cpp
+++ b/kvs/src/main.cpp
@@ -1,31 +1,15 @@
 #include <Arduino.h>
+#include "storage.hpp"
+
+FlashStorage storage;
 
 void setup() {
   Serial.begin(115200);
   delay(5000);
   Serial.println("Initialized.");
-  Serial.printf("Flash size: %d\n", ESP.getFlashChipSize());
-
-  // Dump partition table
-  //
-  // Partition API:
-  // https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/storage/partition.html
-  //
-  // Types:
-  // https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/partition-tables.html
-  //
-  // Alternative partition layouts:
-  // https://github.com/espressif/arduino-esp32/tree/master/tools/partitions
-  auto it = esp_partition_find(ESP_PARTITION_TYPE_ANY, ESP_PARTITION_SUBTYPE_ANY, nullptr);
-  while(it != nullptr) {
-    auto *partition = esp_partition_get(it);
-    Serial.printf("Type: %d Subtype: %d, Addr: 0x%x, Size: 0x%x Label: %s\n",
-        partition->type, partition->subtype, partition->address, partition->size,
-        partition->label != nullptr ? partition->label : "<no label>");
-    it = esp_partition_next(it);
-  }
-
-  // TODO: create custom partition table, find it, experiment with writting/overwritting flash.
+  storage.Init();
+  auto value = storage.Get("foo");
+  Serial.println(value.c_str());
 }
 
 void loop() {

--- a/kvs/src/storage.cpp
+++ b/kvs/src/storage.cpp
@@ -1,0 +1,197 @@
+#include "storage.hpp"
+#include "Arduino.h"
+#include "esp_debug_helpers.h"
+#include "nvs_flash.h"
+#include "rom/crc.h"
+
+const char* Storage::kMagic = "kvs";
+
+void fail() {
+    printf("Abort.\n");
+    esp_backtrace_print(32);
+    while (true) sleep(1);
+}
+
+ void FlashStorage::BoundsCheck(const char*op, uint32_t pos, uint32_t length) {
+  if (pos > length_ || length > length_ || pos + length > length_) {
+    Serial.printf("Out of bounds %s: %d/%d\n", op, pos, length);
+    fail();
+  }
+}
+
+void FlashStorage::Write(uint32_t pos, const char*buf, uint32_t length) {
+  BoundsCheck("write", pos, length);
+
+  esp_err_t res = esp_flash_write(esp_flash_default_chip, buf, start_ + pos, length);
+  if (res != ESP_OK) {
+    printf("Failed to write %d to %d: err %d\n", buf, 0, res);
+    fail();
+  }
+}
+
+void FlashStorage::Read(uint32_t pos, char*buf, uint32_t length) {
+  BoundsCheck("read", pos, length);
+
+  esp_err_t res = esp_flash_read(esp_flash_default_chip, buf, start_ + pos, length);
+  if (res == ESP_OK) {
+    return;
+  } else if (res == ESP_ERR_NO_MEM) {
+    Serial.println("No permissions");
+    fail();
+  } else {
+    Serial.printf("Unknown error reading flash: %d\n", res);
+    fail();
+  }
+}
+
+void FlashStorage::Erase(uint32_t pos, uint32_t length) {
+  BoundsCheck("erase", pos, length);
+  if (length & ~(kBlockSize - 1) != 0 || length == 0) {
+    Serial.printf("Incorrect erase alignment: length=0x%x", length);
+    fail();
+  }
+
+  esp_err_t res = esp_flash_erase_region(esp_flash_default_chip, start_ + pos, length);
+  if (res != ESP_OK) {
+    Serial.printf("Failed to erase, error: %d\n", res);
+    fail();
+  }
+}
+
+bool FlashStorage::Init() {
+  Serial.printf("Flash size: %d\n", ESP.getFlashChipSize());
+
+  // Dump partition table
+  //
+  // Partition API:
+  // https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/storage/partition.html
+  //
+  // Types:
+  // https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/partition-tables.html
+  //
+  // Alternative partition layouts:
+  // https://github.com/espressif/arduino-esp32/tree/master/tools/partitions
+  auto it = esp_partition_find(ESP_PARTITION_TYPE_ANY, ESP_PARTITION_SUBTYPE_ANY, nullptr);
+  while(it != nullptr) {
+    auto *partition = esp_partition_get(it);
+    Serial.printf("Type: %d Subtype: %d, Addr: 0x%x, Size: 0x%x Label: %s\n",
+        partition->type, partition->subtype, partition->address, partition->size,
+        partition->label != nullptr ? partition->label : "<no label>");
+    it = esp_partition_next(it);
+  }
+
+  auto *p = esp_partition_find_first(ESP_PARTITION_TYPE_ANY, ESP_PARTITION_SUBTYPE_ANY, "ffat");
+  if (p == nullptr) {
+    Serial.println("Failed to find ffat partition\n");
+    fail();
+  }
+  start_ = p->address;
+  length_ = p->size;
+
+  esp_err_t res = esp_flash_init(esp_flash_default_chip);
+  if (res != ESP_OK) {
+    Serial.printf("Flash init failure: %d\n", res);
+    fail();
+  }
+
+  return true;
+}
+
+Storage::Status Storage::Put(const char* key, const char* value) {
+
+  uint32_t key_length = strlen(key);
+  uint32_t value_length = strlen(value);
+  uint32_t total_length = key_length + value_length;
+
+  if (key_length + value_length > 254) {
+    Serial.printf("Total length too big %d\n", total_length);
+    return STORAGE_INVALID_ARG;
+  }
+
+  char buf[256];
+  uint8_t lens[2];
+  uint32_t offset = 0;
+  ReadNext(&offset, buf, strlen(kMagic));
+
+  // Not initialized, do lazy init
+  if (strncmp(buf, kMagic, strlen(kMagic)) != 0) {
+    Erase(0, kBlockSize);
+    Write(0, kMagic, strlen(kMagic));
+  } else {
+    while (true) {
+      ReadNext(&offset, (char*)lens, sizeof(lens));
+      // End of log
+      if (lens[0] == 255) break;
+
+      // Key size match, check if old key matches
+      if (lens[1] == key_length) {
+        ReadNext(&offset, buf, key_length);
+
+        if (strncmp(buf, key, key_length) == 0) {
+          // Wipe old key, value and key length
+          bzero(buf, lens[0] + 1);
+          Write(offset - key_length - 1, buf, lens[0] + 1);
+        }
+        // Skip value
+        offset += lens[0] - lens[1];
+      } else {
+        // Skip key and value
+        offset += lens[0];
+      }
+    }
+    // Go back for the header size
+    offset -= sizeof(lens);
+  }
+  uint32_t end_offset = offset + 2 + total_length;
+
+  // First, make sure next flash page is cleared lazily if needed
+  // Keep 256 bytes cleared after the end of the new record.
+  uint32_t old_cleared_page = (offset + 256) / kBlockSize;
+  uint32_t new_cleared_page = (end_offset + 256) / kBlockSize;
+  if (new_cleared_page != old_cleared_page) {
+    Erase(new_cleared_page * kBlockSize, kBlockSize);
+  }
+  // Write total length first. If it fails we just have a bad record.
+  // Serial.printf("Write record %d len %d\n", offset, total_length + 2);
+  Write(offset, (char*)&total_length, 1);
+  Write(offset + 1, (char*)&key_length, 1);
+  Write(offset + 2, key, key_length);
+  Write(offset + 2 + key_length, value, value_length);
+  return STORAGE_OK;
+}
+
+std::string Storage::Get(const char *key) {
+  char buf[256];
+  uint8_t lens[2];
+
+  uint32_t offset = 0;
+  ReadNext(&offset, buf, strlen(kMagic));
+
+  // Not initialized, no result
+  if (strncmp(buf, kMagic, strlen(kMagic)) != 0)
+    return "";
+
+  uint32_t key_length = strlen(key);
+
+  while (true) {
+    ReadNext(&offset, (char*)lens, sizeof(lens));
+    if (lens[0] == 255) return "";
+    if (lens[1] < lens[0] && lens[1] == key_length) {
+      // Key length match, read key
+      ReadNext(&offset, buf, lens[1]);
+      if (strncmp(buf, key, key_length) == 0) {
+        // Found match, read value
+        ReadNext(&offset, buf, lens[0] - lens[1]);
+        return std::string(buf, lens[0] - lens[1]);
+      } else {
+        offset += lens[0] - lens[1];
+      }
+    } else {
+      offset += lens[0];
+    }
+  }
+}
+
+std::string Storage::List() const {
+    return "Not implemented yet";
+}

--- a/kvs/test/storage_test.cpp
+++ b/kvs/test/storage_test.cpp
@@ -1,0 +1,115 @@
+#include <memory>
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <Arduino.h>
+#include <string.h>
+#include "storage.hpp"
+#include "storage.cpp"
+
+class MockStorage : public Storage {
+  public:
+    bool Init() override {
+      for (int i = 0; i < kSize; i++) {
+        data_[i] = i;
+      }
+      return true;
+    }
+
+    int NumBlocksErased() { return erased_blocks_; }
+    void Dump() {
+      for (int i = 0; i < 100; i++)
+        Serial.printf("%d:%d(%c) ", i, data_[i], data_[i] > 32 ? data_[i] : '?' );
+      Serial.println();
+    }
+
+  protected:
+    void BoundsCheck(uint32_t pos, uint32_t length) {
+      if (pos + length > kSize) fail();
+    }
+
+    void Write(uint32_t pos, const char*buf, uint32_t length) {
+      BoundsCheck(pos, length);
+      for (uint32_t i = 0; i < length; i++) {
+        // Can only reset bits without erasing
+        data_[pos + i] &= buf[i];
+      }
+    }
+    void Read(uint32_t pos, char *buf, uint32_t length) {
+      BoundsCheck(pos, length);
+      // Serial.printf("read %d len %d\n", pos, length);
+      bcopy(data_ + pos, buf, length);
+    }
+    void Erase(uint32_t pos, uint32_t length) {
+      BoundsCheck(pos, length);
+      for(int i = 0; i < length; i++) {
+        data_[pos + i] = 0xff;
+      }
+      erased_blocks_ += length / kBlockSize;
+    }
+
+   static const uint32_t kSize = 16384;
+   char data_[kSize];
+   int erased_blocks_ = 0;
+};
+
+TEST(StorageTest, Foo) {
+  using testing::Eq;
+
+  Serial.println("Start testing");
+
+  // WTF? No unique_ptr
+  auto s = new MockStorage();
+  // auto s = new FlashStorage();
+
+  s->Init();
+  // Check empty read works
+  EXPECT_THAT(s->Get("bar"), Eq(""));
+
+  s->Put("zzzzzzzz", "a");
+  s->Put("foo", "123");
+  s->Put("bar", "456");
+  EXPECT_THAT(s->Get("bar"), Eq("456"));
+  EXPECT_THAT(s->Get("foo"), Eq("123"));
+  EXPECT_THAT(s->Get("baz"), Eq(""));
+
+  // Not implemented yet
+  // EXPECT_THAT(s->List(), Eq("foo\nbar\n"));
+
+  EXPECT_THAT(s->NumBlocksErased(), Eq(1));
+
+  // Test that lazy erase works
+  for (int i = 0; i < 1024; i++) {
+    Serial.print(".");
+    // 4 bytes * 1024
+    EXPECT_THAT(s->Put("a", "b"), Eq(Storage::Status::STORAGE_OK));
+  }
+
+  EXPECT_THAT(s->Get("a"), Eq("b"));
+  EXPECT_THAT(s->NumBlocksErased(), Eq(2));
+
+  // Check overwrite
+  s->Put("foo", "new value");
+  EXPECT_THAT(s->Get("foo"), Eq("new value"));
+
+  Serial.println("End testing");
+  s->Dump();
+  delete s;
+}
+
+void setup() {
+    Serial.begin(115200);
+
+    ::testing::InitGoogleTest();
+    ::testing::InitGoogleMock();
+
+  // Run tests
+  if (RUN_ALL_TESTS())
+  ;
+}
+
+void loop() {
+
+  // sleep for 1 sec
+  delay(1000);
+}


### PR DESCRIPTION
The data stored in the format:
[magic 'kvs'][record][record]...

The records consist of:
1 byte total record length [0..254]
1 byte key length [0..254]
N bytes key
M bytes value

Flash storage is allocated and erased on demand.
Added unittest for the storage implementation which doesn't write to flash by default, but can write as well.